### PR TITLE
Yarn version update

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
   publish = "public"
   command = "npm run build"
 [build.environment]
-  YARN_VERSION = "1.3.2"
+  YARN_VERSION = "1.9.4"
   YARN_FLAGS = "--no-ignore-optional"


### PR DESCRIPTION
This is a PR for issue #134.
I started to experience weird build issues during netlify deployment. Mostly with `childImageSharp`, basically the same error message as what on #133 and #128. This was running fine on my machine and on my machine i had `yarn` with  version **1.9.4**. After updating the yarn version the deployment was succesfull.
Just as a sidenote i added Yarn as prerequisite, because we maintain the package dependencies with yarn and folks using only npm can experience issues, so just to avoid a big wave of questions in the future, i think we need make yarn a prerequisite