### PR TITLE
Lighthouse SEO score improvements

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: 'Gatsby + Netlify CMS Starter',
+    description: 'This repo contains an example business website that is built with Gatsby, and Netlify CMS.It follows the JAMstack architecture by using Git as a single source of truth, and Netlify for continuous deployment, and CDN distribution.',
   },
   plugins: [
     'gatsby-plugin-react-helmet',

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,15 +1,34 @@
 import React from 'react'
 import Helmet from 'react-helmet'
+import { StaticQuery, graphql } from "gatsby"
 
 import Navbar from '../components/Navbar'
 import './all.sass'
 
 const TemplateWrapper = ({ children }) => (
-  <div>
-    <Helmet title="Home | Gatsby + Netlify CMS" />
-    <Navbar />
-    <div>{children}</div>
-  </div>
+  <StaticQuery
+    query={graphql`
+      query HeadingQuery {
+          site {
+            siteMetadata {
+              title,
+              description,
+            }
+          }
+        }
+    `}
+    render={data => (
+      <div>
+        <Helmet>
+          <html lang="en" />
+          <title>{data.site.siteMetadata.title}</title>
+          <meta name="description" content={data.site.siteMetadata.description} />
+        </Helmet>
+        <Navbar />
+        <div>{children}</div>
+      </div>
+    )}
+  />
 )
 
 export default TemplateWrapper


### PR DESCRIPTION
This PR adds title and meta name description to all pages, except on the blog posts, in those cases the description tag is already filled up from the blogpost content.
title and meta description is now grabbed from `gatsby-config.js`.
In the `Layout.js` file i added a `<StaticQuery>` just to speed up things and give us more flexibility in the future for extending the header (for instance the google meta tag or other facebook and twitter meta tags)
This pretty much bumps our SEO score to 100% on all pages.