### PR TITLE
Allow svg, gif & pdfs to be properly linked

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -49,6 +49,12 @@ module.exports = {
               maxWidth: 2048,
             },
           },
+          {
+            resolve: 'gatsby-remark-copy-linked-files',
+            options: {
+              destinationDir: 'static',
+            }
+          }
         ],
       },
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-netlify-cms": "^3.0.0",
     "gatsby-plugin-purgecss": "^2.4.0",
     "gatsby-plugin-react-helmet": "^3.0.0",
-    "gatsby-remark-copy-linked-files: "^2.0.6",
+    "gatsby-remark-copy-linked-files": "^2.0.6",
     "gatsby-plugin-sass": "^2.0.1",
     "gatsby-plugin-sharp": "^2.0.5",
     "gatsby-remark-images": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gatsby-plugin-netlify-cms": "^3.0.0",
     "gatsby-plugin-purgecss": "^2.4.0",
     "gatsby-plugin-react-helmet": "^3.0.0",
+    "gatsby-remark-copy-linked-files: "^2.0.6",
     "gatsby-plugin-sass": "^2.0.1",
     "gatsby-plugin-sharp": "^2.0.5",
     "gatsby-remark-images": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6030,6 +6030,20 @@ gatsby-react-router-scroll@^2.0.1:
     scroll-behavior "^0.9.9"
     warning "^3.0.0"
 
+gatsby-remark-copy-linked-files@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.0.6.tgz#fd0a3fd696fbc68196a1d1058cc757fb6651e2b3"
+  integrity sha512-GG9cXboQ0fBnJYnsEfj2kXim+yAx0++coNnXaiGK388AazajUzcNt2YyuBA0S4aZgia0yEi9y8ZJg/0UtTk5Tg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    cheerio "^1.0.0-rc.2"
+    fs-extra "^4.0.1"
+    is-relative-url "^2.0.0"
+    lodash "^4.17.10"
+    path-is-inside "^1.0.2"
+    probe-image-size "^4.0.0"
+    unist-util-visit "^1.3.0"
+
 gatsby-remark-images@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.0.0.tgz#ec4fa67ff6e16480523d42fca4795a60581fc1fb"


### PR DESCRIPTION
The current template doesn't support properly changing path of svg, gif and pdf documents because `gatsby-remark-images` ignores these files. This PR adds `gatsby-remark-copy-linked-files` to config and `package.json`.

It took almost a day to figure out why this was happening. It's too frustrating for someone who's new to both Gatsby and NetlifyCMS.