### PR TITLE
Purgecss develop improvements

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -64,7 +64,13 @@ module.exports = {
         modulePath: `${__dirname}/src/cms/cms.js`,
       },
     },
-    'gatsby-plugin-purgecss', // must be after other CSS plugins
+    {
+      resolve:'gatsby-plugin-purgecss', // purges all unused/unreferenced css rules
+      options: {
+        develop: true,            // Activates purging in npm run develop
+        purgeOnly: ['/all.sass'], // applies purging only on the bulma css file
+      },
+    }, // must be after other CSS plugins
     'gatsby-plugin-netlify', // make sure to keep it last in the array
   ],
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "gatsby-image": "^2.0.23",
     "gatsby-plugin-netlify": "^2.0.6",
     "gatsby-plugin-netlify-cms": "^3.0.9",
-    "gatsby-plugin-purgecss": "^3.0.0",
+    "gatsby-plugin-purgecss": "^3.1.0",
     "gatsby-plugin-react-helmet": "^3.0.4",
     "gatsby-plugin-sass": "^2.0.7",
     "gatsby-plugin-sharp": "^2.0.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5076,9 +5076,9 @@ gatsby-plugin-page-creator@^2.0.5:
     parse-filepath "^1.0.1"
     slash "^1.0.0"
 
-gatsby-plugin-purgecss@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-purgecss/-/gatsby-plugin-purgecss-3.0.0.tgz#3d9ab151f6b8098053e272a461f2d3680c89a291"
+gatsby-plugin-purgecss@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-purgecss/-/gatsby-plugin-purgecss-3.1.0.tgz#ecaf5266317ef3deba94478f341f2855f58a3a74"
   dependencies:
     fs-extra "^7.0.0"
     loader-utils "^1.1.0"


### PR DESCRIPTION
This fixes #160 

1. by setting purgecss plugin to `develop: true` will activate purging in develop mode, so theoretically there won't be any difference between `npm run develop` and `npm run build`
2. the purging will only be applied for the bulma css templates, all other css file will be ignored.

For the latter i needed to bump the purge-css to 3.1.0