### PR TITLE
Update React Helmet import

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Helmet from 'react-helmet'
+import { Helmet } from 'react-helmet'
 import Footer from '../components/Footer'
 import Navbar from '../components/Navbar'
 import './all.sass'


### PR DESCRIPTION
This project uses gatsby-plugin-react-helmet, which can cause errors when used with React hooks. Importing React Helmet as a named import rather than a default import can prevent these.

**What kind of change does this PR introduce?**

This changes how React Helmet is imported into `src/components/Layout.js` to the new method documented in [gatsby-plugin-react-helmet's documentation](https://www.gatsbyjs.org/packages/gatsby-plugin-react-helmet/)

**Does this PR introduce a breaking change?**

No, the only change is the import method for React Helmet.

**What needs to be documented once your changes are merged?**

No documentation changes needed!
