### PR TITLE
Fixes undefined featured image alt text attribute

### DIFF
--- a/src/components/BlogRoll.js
+++ b/src/components/BlogRoll.js
@@ -24,7 +24,7 @@ class BlogRoll extends React.Component {
                       <PreviewCompatibleImage
                         imageInfo={{
                           image: post.frontmatter.featuredimage,
-                          alt: `featured image thumbnail for post ${post.title}`,
+                          alt: `featured image thumbnail for post ${post.frontmatter.title}`,
                         }}
                       />
                     </div>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
When running the code the alt text for a featured image in the BlogRoll
will read `featured image thumbnail for post undefined` as the variable
wasn't quite right. This PR fixes that.

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
Nothing
