### PR TITLE
fix(blog-template): convert immutable list to array

### DIFF
--- a/src/cms/preview-templates/BlogPostPreview.js
+++ b/src/cms/preview-templates/BlogPostPreview.js
@@ -2,14 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { BlogPostTemplate } from '../../templates/blog-post'
 
-const BlogPostPreview = ({ entry, widgetFor }) => (
-  <BlogPostTemplate
-    content={widgetFor('body')}
-    description={entry.getIn(['data', 'description'])}
-    tags={entry.getIn(['data', 'tags'])}
-    title={entry.getIn(['data', 'title'])}
-  />
-)
+const BlogPostPreview = ({ entry, widgetFor }) => {
+  const tags = entry.getIn(['data', 'tags'])
+  return (
+    <BlogPostTemplate
+      content={widgetFor('body')}
+      description={entry.getIn(['data', 'description'])}
+      tags={tags && tags.toJS()}
+      title={entry.getIn(['data', 'title'])}
+    />
+  )
+}
 
 BlogPostPreview.propTypes = {
   entry: PropTypes.shape({


### PR DESCRIPTION
Fixes https://github.com/netlify-templates/gatsby-starter-netlify-cms/issues/451

Tags is an immutable List and should be converted to JavaScript objects before passing into the component.