### PR TITLE
fix: use getAsset in preview templates

### DIFF
--- a/src/cms/preview-templates/IndexPagePreview.js
+++ b/src/cms/preview-templates/IndexPagePreview.js
@@ -8,7 +8,7 @@ const IndexPagePreview = ({ entry, getAsset }) => {
   if (data) {
     return (
       <IndexPageTemplate
-        image={data.image}
+        image={getAsset(data.image)}
         title={data.title}
         heading={data.heading}
         subheading={data.subheading}

--- a/src/cms/preview-templates/ProductPagePreview.js
+++ b/src/cms/preview-templates/ProductPagePreview.js
@@ -14,7 +14,7 @@ const ProductPagePreview = ({ entry, getAsset }) => {
 
   return (
     <ProductPageTemplate
-      image={entry.getIn(['data', 'image'])}
+      image={getAsset(entry.getIn(['data', 'image']))}
       title={entry.getIn(['data', 'title'])}
       heading={entry.getIn(['data', 'heading'])}
       description={entry.getIn(['data', 'description'])}


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3158

`getAsset` works both for uncommitted and committed images