### PR TITLE
Make footer max width 100vw to fix lighthouse test error

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -20,7 +20,7 @@ const Footer = class extends React.Component {
         </div>
         <div className="content has-text-centered has-background-black has-text-white-ter">
           <div className="container has-background-black has-text-white-ter">
-            <div style={{ max-width: '100vw' }} className="columns">
+            <div style={{ maxWidth: '100vw' }} className="columns">
               <div className="column is-4">
                 <section className="menu">
                   <ul className="menu-list">

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -20,7 +20,7 @@ const Footer = class extends React.Component {
         </div>
         <div className="content has-text-centered has-background-black has-text-white-ter">
           <div className="container has-background-black has-text-white-ter">
-            <div className="columns">
+            <div style={{ max-width: '100vw' }} className="columns">
               <div className="column is-4">
                 <section className="menu">
                   <ul className="menu-list">


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

Follow up to this [issue](https://github.com/netlify-templates/gatsby-starter-netlify-cms/issues/573#issuecomment-631348332)

Lighthouse was giving an error on the Mobile viewport:

The viewport size is 424px, whereas the window size is 412px. This can be seen on mobile phone size screens when you swipe left the page moves.

This PR restricts the width of the footer to 100vw which fixes this.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
