### PR TITLE
#629: remove deprecated super(props) from components

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -4,8 +4,8 @@ import github from '../img/github-icon.svg'
 import logo from '../img/logo.svg'
 
 const Navbar = class extends React.Component {
-  constructor(props) {
-    super(props)
+  constructor() {
+    super()
     this.state = {
       active: false,
       navBarActiveClass: '',

--- a/src/pages/contact/file-upload.js
+++ b/src/pages/contact/file-upload.js
@@ -13,8 +13,8 @@ function encode(data) {
 }
 
 export default class Contact extends React.Component {
-  constructor(props) {
-    super(props)
+  constructor() {
+    super()
     this.state = {}
   }
 

--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -9,8 +9,8 @@ function encode(data) {
 }
 
 export default class Index extends React.Component {
-  constructor(props) {
-    super(props)
+  constructor() {
+    super()
     this.state = { isValidated: false }
   }
 


### PR DESCRIPTION
# Summary

This PR addresses [issue 629](https://github.com/netlify-templates/gatsby-starter-netlify-cms/issues/629), which removes the deprecated `super(props)` invocations from React components in favour of `super()`. No functionality is otherwise affected.

## Change Type: Refactor

## Breaking changes

None

## Testing required

No testing required.

## Documentation

No change to documentation should be required.