### PR TITLE
Make the Gatsby CLI link navigate to an actual Gatsby CLI page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It follows the [JAMstack architecture](https://jamstack.org) by using Git as a s
 ## Prerequisites
 
 - Node (I recommend using v8.2.0 or higher)
-- [Gatsby CLI](https://www.gatsbyjs.org/docs/)
+- [Gatsby CLI](https://www.gatsbyjs.com/docs/reference/gatsby-cli/)
 - [Netlify CLI](https://github.com/netlify/cli)
 
 ## Getting Started (Recommended)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Minor fix in README. Before the link navigated to a general Gatsby docs page, where there was no information on how to install Gatsby CLI. Now it navigates directly to a page dedicated for Gatsby CLI.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**
No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Nothing.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
