### PR TITLE
Update names, links, and scripts to latest in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ It follows the [JAMstack architecture](https://jamstack.org) by using Git as a s
 - Create Blog posts from Netlify CMS
 - Tags: Separate page for posts under each tag
 - Basic directory organization
-- Uses Bulma for styling, but size is reduced by `purge-css-plugin`
+- Uses Bulma for styling, but size is reduced by `gatsy-plugin-purgecss`
 - Blazing fast loading times thanks to pre-rendered HTML and automatic chunk loading of JS files
-- Uses `gatsby-image` with Netlify-CMS preview support
+- Uses `gatsby-plugin-image` with Netlify-CMS preview support
 - Separate components for everything
 - Netlify deploy configuration
-- Netlify function support, see `lambda` folder
+- Netlify function support, see `netlify/functions` folder
 - Perfect score on Lighthouse for SEO, Accessibility and Performance (wip:PWA)
 - ..and more
 
@@ -49,7 +49,7 @@ $ yarn
 $ netlify dev # or ntl dev
 ```
 
-This uses the new [Netlify Dev](https://www.netlify.com/products/dev/?utm_source=blog&utm_medium=netlifycms&utm_campaign=devex) CLI feature to serve any functions you have in the `lambda` folder.
+This uses [Netlify Dev](https://www.netlify.com/products/dev/?utm_source=blog&utm_medium=netlifycms&utm_campaign=devex) CLI feature to serve any functions you have in the `netlify/functions` folder.
 
 To test the CMS locally, you'll need to run a production build of the site:
 
@@ -100,12 +100,16 @@ yarn remove netlify-cms-media-library-cloudinary
 $ gatsby new [SITE_DIRECTORY_NAME] https://github.com/netlify-templates/gatsby-starter-netlify-cms/
 $ cd [SITE_DIRECTORY_NAME]
 $ npm run build
-$ npm run serve
+$ npm run start
 ```
 
 ### Setting up the CMS
 
-Follow the [Netlify CMS Quick Start Guide](https://www.netlifycms.org/docs/quick-start/#authentication) to set up authentication, and hosting.
+Follow the [Netlify CMS Quick Start Guide](https://www.netlifycms.org/docs/quick-start/#authentication) to set up authentication, and hosting for production.
+
+If you want use Netlify CMS locally, run the site in one terminal with `npm run start` and in another
+Terminal you can use `npx netlify-cms-proxy-server` which proxy requests so you'll be automatically logged
+in as a user on [http:localhost:3000/admin](http:localhost:3000/admin).
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ in as a user on [http:localhost:3000/admin](http:localhost:3000/admin).
 
 ## Debugging
 
-Windows users might encounter `node-gyp` errors when trying to npm install.
+Windows users, who aren't using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about), might encounter `node-gyp` errors when trying to npm install.
 To resolve, make sure that you have both Python 2.7 and the Visual C++ build environment installed.
 
 ```
@@ -121,9 +121,9 @@ npm config set python python2.7
 npm install --global --production windows-build-tools
 ```
 
-[Full details here](https://www.npmjs.com/package/node-gyp "NPM node-gyp page")
+[Full details here](https://www.npmjs.com/package/node-gyp "NPM node-gyp page").
 
-MacOS users might also encounter some errors, for more info check [node-gyp](https://github.com/nodejs/node-gyp). We recommend using the latest stable node version.
+MacOS and WSL users who might also encounter some errors, check [node-gyp](https://github.com/nodejs/node-gyp) for more info. We recommend using the latest stable node version.
 
 ## Purgecss
 


### PR DESCRIPTION
There are a few spots in the README that need to be updated due to changes made over time:

- With our upgrade to Gatsby v4, we want to make sure to list package names as they appear now. Most Gatsby plugins will have the `gatsby-plugin-*` prefix.
- Update where our Netlify Functions are located: `lambda` -> `netlify/functions`
- Replace our start script without Netlify from `npm run serve` -> `npm run start`
- Include how to locally access the CMS

Closes #657 