### PR TITLE
Added min-height for .section class to prevent blank space below footer

### DIFF
--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -13,6 +13,10 @@ $black: #2b2523
 .navbar .navbar-menu
   box-shadow: none !important
 
+.section 
+  min-height: 50.6vh
+
+
 .content .taglist
   list-style: none
   margin-bottom: 0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
## Summary
This PR adresses issue #789. In certain cases the footer had a white space underneath, this usually happens because there is not enough content to push it all the way down, or because the height of the content is too small. The only thing I did was to add a minimum height completely insignificat for the layout of the website, but that pushes the footer to the bottom.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Adds a min-height:50.6vh to the .section classes, this does not generate any conflict in any section of the page, there's no layout change, and is large enough to push the footer down.

**Does this PR introduce a breaking change?**

No, it only makes the footer always be at the bottom of the page, without a white space underneath.

**What needs to be documented once your changes are merged?**

Nothing :).