### PR TITLE
fix: Update the branch to main for NetlifyCMS

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: master
+  branch: main
   commit_messages:
     create: "Create {{collection}} “{{slug}}”"
     update: "Update {{collection}} “{{slug}}”"


### PR DESCRIPTION
## Summary

When a user goes and creates a site through a DTN or the the user interface, we will want to make sure that NetlifyCMS works with their `main` branch. Previously, it used to exclusively work with `master` but since we've made our move over, we will want this to point against what will be registered in production.

UI wise, there should be no updates.


### Relevant issues or documentation
- Fixes #857
- [NetlifyCMS - Setting up backend](https://www.netlifycms.org/docs/add-to-your-site/#backend)